### PR TITLE
Add README with project overview and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Siedler
+
+A lightweight PHP/jQuery prototype inspired by *Settlers of Catan*. It provides a simple login flow backed by a MySQL database and renders a draggable, randomized hex game board in the browser.
+
+## Features
+- Login page that validates users against the configured MySQL database.
+- Game view that renders a randomized hex tile layout and number tokens.
+- Draggable board area for easier viewing on smaller screens.
+
+## Tech stack
+- PHP (routing, login, database access)
+- MySQL (user table lookup)
+- HTML/CSS/JavaScript with jQuery + jQuery UI
+
+## Project structure
+- `index.php` — entry point and basic router.
+- `controller.php` — controller actions and template rendering.
+- `entities/` — database connection + user model.
+- `views/` — HTML templates for login, home, and game field.
+- `styles/`, `js/`, `images/` — static assets.
+
+## Local setup
+1. **Ensure PHP is installed** (PHP 7+ recommended).
+2. **Configure the database connection** in `entities/db.php`.
+   - Update the host, database, user, and password to your local MySQL instance.
+3. **Start the PHP built-in server** from the project root:
+
+   ```bash
+   php -S 0.0.0.0:8000
+   ```
+
+4. Open `http://localhost:8000` in your browser.
+
+## Login flow
+- The login form posts credentials, hashes the password with MD5, and forwards to `index.php?aktion=login`.
+- The controller checks credentials with `User::findeNachUsernameUndPassword()`.
+
+## Notes
+- The current database connection in `entities/db.php` points to a remote MySQL instance. Replace it for local development.
+- Passwords are hashed with MD5 in this prototype; consider stronger hashing (e.g., `password_hash`) if evolving this project.


### PR DESCRIPTION
### Motivation
- Provide a concise project overview and onboarding instructions so new contributors can run the prototype locally.
- Document the project structure, tech stack, and the login/game flow to make maintenance and exploration easier.
- Surface important development notes such as the default remote DB connection and the weak MD5 password hashing used in this prototype.

### Description
- Add `README.md` at the project root containing an overview, feature list, tech stack, project structure, local setup steps, login flow, and notes.
- Include the example command to start the built-in PHP server (`php -S 0.0.0.0:8000`) and instructions to configure `entities/db.php` for local development.
- Call out security and configuration notes including the remote MySQL connection in `entities/db.php` and the current use of MD5 for passwords.

### Testing
- No automated tests were run because this is a documentation-only change.
- CI/linting was not executed as part of this update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69602424e3408331a21db67f0b67be49)